### PR TITLE
Revert change to .gitmodules and update submodule pointer for ccpp-physics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/dustinswales/ccpp-physics
-	branch = dtc/develop
+	url = https://github.com/NCAR/ccpp-physics
+	branch = master


### PR DESCRIPTION
As it says, required after merging https://github.com/NCAR/ccpp-physics/pull/446.