### PR TITLE
Fill out grid DDT from MPAS

### DIFF
--- a/mpas/atmos_coupling.F90
+++ b/mpas/atmos_coupling.F90
@@ -209,8 +209,8 @@ contains
        enddo
     enddo
     
-    physics_grid % xlat(:) = MPAS_state % lat(:)
-    physics_grid % xlon(:) = MPAS_state % lon(:)
+    physics_grid % xlat(1:iCol) = MPAS_state % lat(1:iCol)
+    physics_grid % xlon(1:iCol) = MPAS_state % lon(1:iCol)
     
     ! Compute hydrostatic pressures
     allocate(MPAS_state % pmid(   nVertLevels,   nCellsSolve))

--- a/mpas/atmos_coupling.F90
+++ b/mpas/atmos_coupling.F90
@@ -382,7 +382,8 @@ contains
     use mpas_kind_types,      only : RKIND
     use mpas_constants,       only : pii
     use mpas_log,             only : mpas_log_write
-    use mpp_mod,              only : mpp_error
+    use mpas_derived_types,   only : MPAS_LOG_ERR, MPAS_LOG_WARN
+    use mpp_mod,              only : mpp_error, FATAL
     ! Arguments
     type(GFS_grid_type),      intent(inout) :: physics_grid
     ! Locals
@@ -393,9 +394,10 @@ contains
     
     real(RKIND), pointer :: nominalMinDc
     real(RKIND), pointer :: config_len_disp
-    real(RKIND), parameter  :: rad2deg = 180.0_RKIND/pii
+    real(RKIND)          :: rad2deg
     
     ierr = 0
+    rad2deg = 180.0_RKIND/pii
     
     ! Access MPAS data pools.
     call mpas_pool_get_subpool(domain_ptr % blocklist % structs, 'mesh',  mesh_pool)

--- a/mpas/atmos_coupling.F90
+++ b/mpas/atmos_coupling.F90
@@ -209,8 +209,8 @@ contains
        enddo
     enddo
     
-    physics_grid % xlat(1:iCol) = MPAS_state % lat(1:iCol)
-    physics_grid % xlon(1:iCol) = MPAS_state % lon(1:iCol)
+    physics_grid % xlat(1:nCellsSolve) = MPAS_state % lat(1:nCellsSolve)
+    physics_grid % xlon(1:nCellsSolve) = MPAS_state % lon(1:nCellsSolve)
     
     ! Compute hydrostatic pressures
     allocate(MPAS_state % pmid(   nVertLevels,   nCellsSolve))

--- a/mpas/atmos_coupling.F90
+++ b/mpas/atmos_coupling.F90
@@ -157,7 +157,8 @@ contains
     use atm_core,             only : atm_compute_output_diagnostics
     use mpas_kind_types,      only : RKIND
     ! Arguments
-    type(GFS_statein_type),   intent(inout) :: physics_state, physics_grid
+    type(GFS_statein_type),   intent(inout) :: physics_state
+    type(GFS_grid_type),      intent(inout) :: physics_grid
     ! Locals
     type(mpas_stateout_type) :: mpas_state
     type(mpas_pool_type), pointer :: state_pool

--- a/mpas/atmos_coupling.F90
+++ b/mpas/atmos_coupling.F90
@@ -106,7 +106,10 @@ module atmos_coupling_mod
                                                   ! layer interface [1] (nlev)
      real(mpas_kind), pointer :: fzp(:)           ! Interp weight from k-1 layer midpoint to k
                                                   ! layer interface [dimensionless] (nlev)
-
+     ! MPAS horizontal coordinate (invariant)
+     real(mpas_kind), pointer :: lat(:)           ! latitude (ncol)
+     real(mpas_kind), pointer :: lon(:)           ! longitude (ncol)
+     
      ! Indices for tracer (scalar) indices
      integer, pointer  :: index_qv                ! Tracer index for water-vapor mixing-ratio
      
@@ -147,14 +150,14 @@ contains
   !> CCPP "state" needed by the physics.
   !>
   !> #########################################################################################
-  subroutine ufs_mpas_to_physics(physics_state)
-    use GFS_typedefs,         only : GFS_statein_type
+  subroutine ufs_mpas_to_physics(physics_state, physics_grid)
+    use GFS_typedefs,         only : GFS_statein_type, GFS_grid_type
     use mpas_derived_types,   only : mpas_pool_type
     use mpas_pool_routines,   only : mpas_pool_get_subpool, mpas_pool_get_array, mpas_pool_get_dimension
     use atm_core,             only : atm_compute_output_diagnostics
     use mpas_kind_types,      only : RKIND
     ! Arguments
-    type(GFS_statein_type),   intent(inout) :: physics_state
+    type(GFS_statein_type),   intent(inout) :: physics_state, physics_grid
     ! Locals
     type(mpas_stateout_type) :: mpas_state
     type(mpas_pool_type), pointer :: state_pool
@@ -186,6 +189,8 @@ contains
     call mpas_pool_get_array(mesh_pool,  'zz',                     MPAS_state % zz)
     call mpas_pool_get_array(state_pool, 'theta_m',                MPAS_state % theta_m, timeLevel=1)
     call mpas_pool_get_array(state_pool, 'rho_zz',                 MPAS_state % rho_zz,  timeLevel=1)
+    call mpas_pool_get_array(mesh_pool,  'latCell',                MPAS_state % lat)
+    call mpas_pool_get_array(mesh_pool,  'lonCell',                MPAS_state % lon)
     
     ! Copy fields from MPAS data containers to physics data containers.
     ! [k, i] -> [i, k]
@@ -202,7 +207,10 @@ contains
           physics_state % qgrs(iCol,:,iTracer) = MPAS_state % tracers(iTracer,nVertLevels:1:-1,iCol)
        enddo
     enddo
-
+    
+    physics_grid % xlat(:) = MPAS_state % lat(:)
+    physics_grid % xlon(:) = MPAS_state % lon(:)
+    
     ! Compute hydrostatic pressures
     allocate(MPAS_state % pmid(   nVertLevels,   nCellsSolve))
     allocate(MPAS_state % pmiddry(nVertLevels,   nCellsSolve))

--- a/mpas/atmos_coupling.F90
+++ b/mpas/atmos_coupling.F90
@@ -13,6 +13,7 @@ module atmos_coupling_mod
   public :: ufs_mpas_to_physics
   public :: ufs_microphysics_to_mpas
   public :: ufs_mpas_to_microphysics
+  public :: ufs_mpas_grid_to_physics
 
   !> #######################################################################################
   !> MPAS_statein_type
@@ -106,10 +107,7 @@ module atmos_coupling_mod
                                                   ! layer interface [1] (nlev)
      real(mpas_kind), pointer :: fzp(:)           ! Interp weight from k-1 layer midpoint to k
                                                   ! layer interface [dimensionless] (nlev)
-     ! MPAS horizontal coordinate (invariant)
-     real(mpas_kind), pointer :: lat(:)           ! latitude (ncol)
-     real(mpas_kind), pointer :: lon(:)           ! longitude (ncol)
-     
+
      ! Indices for tracer (scalar) indices
      integer, pointer  :: index_qv                ! Tracer index for water-vapor mixing-ratio
      
@@ -150,15 +148,14 @@ contains
   !> CCPP "state" needed by the physics.
   !>
   !> #########################################################################################
-  subroutine ufs_mpas_to_physics(physics_state, physics_grid)
-    use GFS_typedefs,         only : GFS_statein_type, GFS_grid_type
+  subroutine ufs_mpas_to_physics(physics_state)
+    use GFS_typedefs,         only : GFS_statein_type
     use mpas_derived_types,   only : mpas_pool_type
     use mpas_pool_routines,   only : mpas_pool_get_subpool, mpas_pool_get_array, mpas_pool_get_dimension
     use atm_core,             only : atm_compute_output_diagnostics
     use mpas_kind_types,      only : RKIND
     ! Arguments
     type(GFS_statein_type),   intent(inout) :: physics_state
-    type(GFS_grid_type),      intent(inout) :: physics_grid
     ! Locals
     type(mpas_stateout_type) :: mpas_state
     type(mpas_pool_type), pointer :: state_pool
@@ -190,8 +187,6 @@ contains
     call mpas_pool_get_array(mesh_pool,  'zz',                     MPAS_state % zz)
     call mpas_pool_get_array(state_pool, 'theta_m',                MPAS_state % theta_m, timeLevel=1)
     call mpas_pool_get_array(state_pool, 'rho_zz',                 MPAS_state % rho_zz,  timeLevel=1)
-    call mpas_pool_get_array(mesh_pool,  'latCell',                MPAS_state % lat)
-    call mpas_pool_get_array(mesh_pool,  'lonCell',                MPAS_state % lon)
     
     ! Copy fields from MPAS data containers to physics data containers.
     ! [k, i] -> [i, k]
@@ -207,11 +202,8 @@ contains
        do iTracer = 1,num_scalars
           physics_state % qgrs(iCol,:,iTracer) = MPAS_state % tracers(iTracer,nVertLevels:1:-1,iCol)
        enddo
-    enddo
-    
-    physics_grid % xlat(1:nCellsSolve) = MPAS_state % lat(1:nCellsSolve)
-    physics_grid % xlon(1:nCellsSolve) = MPAS_state % lon(1:nCellsSolve)
-    
+    enddo    
+
     ! Compute hydrostatic pressures
     allocate(MPAS_state % pmid(   nVertLevels,   nCellsSolve))
     allocate(MPAS_state % pmiddry(nVertLevels,   nCellsSolve))
@@ -378,5 +370,89 @@ contains
        end do
     end do
   end subroutine hydrostatic_pressure
+  
+!> #########################################################################################
+!> Procedure to transfer MPAS grid information to physics DDTs.
+!>
+!> #########################################################################################
+  subroutine ufs_mpas_grid_to_physics(physics_grid)
+    use GFS_typedefs,         only : GFS_grid_type
+    use mpas_derived_types,   only : mpas_pool_type
+    use mpas_pool_routines,   only : mpas_pool_get_subpool, mpas_pool_get_dimension, mpas_pool_get_array, mpas_pool_get_config
+    use mpas_kind_types,      only : RKIND
+    use mpas_constants,       only : pii
+    use mpas_log,             only : mpas_log_write
+    use mpp_mod,              only : mpp_error
+    ! Arguments
+    type(GFS_grid_type),      intent(inout) :: physics_grid
+    ! Locals
+    type(mpas_pool_type), pointer :: mesh_pool
+    integer :: i, ierr
+    integer, pointer :: nCellsSolve
+    real(RKIND), pointer :: lat(:), lon(:), area(:), meshDensity(:)
+    
+    real(RKIND), pointer :: nominalMinDc
+    real(RKIND), pointer :: config_len_disp
+    real(RKIND), parameter  :: rad2deg = 180.0_RKIND/pii
+    
+    ierr = 0
+    
+    ! Access MPAS data pools.
+    call mpas_pool_get_subpool(domain_ptr % blocklist % structs, 'mesh',  mesh_pool)
+    
+    ! Get MPAS dimensions
+    call mpas_pool_get_dimension(mesh_pool,  'nCellsSolve', nCellsSolve)
+    
+    call mpas_pool_get_array(mesh_pool,  'latCell',                lat)
+    call mpas_pool_get_array(mesh_pool,  'lonCell',                lon)
+    call mpas_pool_get_array(mesh_pool,  'areaCell',               area)
+    call mpas_pool_get_array(mesh_pool,  'meshDensity',            meshDensity)
+    
+    ! (from mpas_atm_core.F/atm_core_init Determine horizontal length scale used by horizontal diffusion and 3-d divergence damping
+    nullify(nominalMinDc)
+    call mpas_pool_get_array(mesh_pool, 'nominalMinDc', nominalMinDc)
 
+    nullify(config_len_disp)
+    call mpas_pool_get_config(domain_ptr % blocklist % configs, 'config_len_disp', config_len_disp)
+
+    ! If config_len_disp was specified as a valid value, use that
+    if (config_len_disp > 0.0_RKIND) then
+      ! But if nominalMinDc was available in the input file and is different, print a warning
+      if (nominalMinDc > 0.0_RKIND .and. abs(nominalMinDc - config_len_disp) > 1.0e-6_RKIND * config_len_disp) then
+        call mpas_log_write('nominalMinDc was read from input file as a positive value ($r) that differs', &
+                                realArgs=[nominalMinDc], messageType=MPAS_LOG_WARN)
+        call mpas_log_write('from the specified config_len_disp value ($r)', &
+                                realArgs=[config_len_disp], messageType=MPAS_LOG_WARN)
+      end if
+      nominalMinDc = config_len_disp
+    ! Otherwise, try to use nominalMinDc
+    else
+      if (nominalMinDc > 0.0_RKIND) then
+        call mpas_log_write('Setting config_len_disp to $r based on nominalMinDc value in input file', realArgs=[nominalMinDc])
+          config_len_disp = nominalMinDc
+      else
+        call mpas_log_write('Both config_len_disp and nominalMinDc are <= 0.0.', messageType=MPAS_LOG_ERR)
+        call mpas_log_write('Please either specify config_len_disp in the &nhyd_model namelist group,', &
+                                messageType=MPAS_LOG_ERR)
+        call mpas_log_write('or use an input file that provides a valid value for the nominalMinDc variable.', &
+                                messageType=MPAS_LOG_ERR)
+        ierr = 1
+      end if
+    end if
+    if (ierr/=0)  call mpp_error(FATAL, 'Call to ufs_mpas_grid_to_physics() failed')  
+    
+    do i=1, nCellsSolve
+      physics_grid % xlat(i)   = lat(i)
+      physics_grid % xlon(i)   = lon(i)
+      physics_grid % xlat_d(i) = physics_grid % xlat(i) * rad2deg
+      physics_grid % xlon_d(i) = physics_grid % xlon(i) * rad2deg
+      physics_grid % sinlat(i) = sin(physics_grid % xlat(i))
+      physics_grid % coslat(i) = sqrt(1.0_RKIND - physics_grid % sinlat(i) * physics_grid % sinlat(i))
+      physics_grid % area(i)   = area(i)
+      !formula for dx comes from mpas_atmphys_driver_gwdo.F instead of sqrt(area) as in FV3
+      physics_grid % dx(i)     = config_len_disp / meshDensity(i)**0.25
+    end do
+    
+  end subroutine ufs_mpas_grid_to_physics
+  
 end module atmos_coupling_mod

--- a/mpas/atmos_model.F90
+++ b/mpas/atmos_model.F90
@@ -109,7 +109,7 @@ contains
     use ufs_mpas_subdriver, only : ufs_mpas_init
     use ufs_mpas_subdriver, only : ufs_mpas_open_init, ufs_mpas_open_lbc
     use ufs_mpas_module,    only : constituent_name, is_water_species
-    use atmos_coupling_mod, only : ufs_mpas_to_physics
+    use atmos_coupling_mod, only : ufs_mpas_to_physics, ufs_mpas_grid_to_physics
     use MPAS_init,          only : MPAS_initialize
 
     ! Arguments
@@ -269,6 +269,8 @@ contains
     ! Read in physics namelist and allocate data containers.
     call MPAS_initialize(UFSATM_control, UFSATM_intdiag, UFSATM_grid, UFSATM_tbd, UFSATM_sfcprop, &
          UFSATM_statein, UFSATM_cldprop, UFSATM_radtend, UFSATM_coupling, Cfg)
+    
+    call ufs_mpas_grid_to_physics(UFSATM_grid)
 
     ! Populate UFSATM data containers with MPAS "input" stream. We need to do this becuase
     ! we are calling the physics before the MPAS dynamical core.
@@ -280,7 +282,7 @@ contains
     ! in a different "piece" later, but copying the Updated state from the dycore before calling
     ! the microphsyics.
     !
-    call ufs_mpas_to_physics(UFSATM_statein, UFSATM_grid)
+    call ufs_mpas_to_physics(UFSATM_statein)
 
     ! Initialize the CCPP framework
     call CCPP_step (step="init", nblks=Atmos % nblks, ierr=ierr, dycore='mpas')

--- a/mpas/atmos_model.F90
+++ b/mpas/atmos_model.F90
@@ -280,7 +280,7 @@ contains
     ! in a different "piece" later, but copying the Updated state from the dycore before calling
     ! the microphsyics.
     !
-    call ufs_mpas_to_physics(UFSATM_statein)
+    call ufs_mpas_to_physics(UFSATM_statein, UFSATM_grid)
 
     ! Initialize the CCPP framework
     call CCPP_step (step="init", nblks=Atmos % nblks, ierr=ierr, dycore='mpas')

--- a/mpas/ufs_mpas_module.F90
+++ b/mpas/ufs_mpas_module.F90
@@ -28,8 +28,7 @@ module ufs_mpas_module
   integer, allocatable :: index_mpas_scalar_to_constituent(:)
   logical, allocatable :: is_water_species(:)
 
-  private
-  type (MPAS_Time_Type) :: LBC_intv_end
+  private type (MPAS_Time_Type) :: LBC_intv_end
   
   !> #########################################################################################
   !>

--- a/mpas/ufs_mpas_module.F90
+++ b/mpas/ufs_mpas_module.F90
@@ -28,7 +28,7 @@ module ufs_mpas_module
   integer, allocatable :: index_mpas_scalar_to_constituent(:)
   logical, allocatable :: is_water_species(:)
 
-  private type (MPAS_Time_Type) :: LBC_intv_end
+  type(MPAS_Time_Type), private :: LBC_intv_end
   
   !> #########################################################################################
   !>


### PR DESCRIPTION
Hey Dustin,

I'm not sure if you want to periodically merge my work back in or what, but here are my first code changes if you do!

I'm going through the timestep_init phase of the RRFS_MPAS suite and found that there are a bunch of uninitialized variables in GFS_phys_time_vary, so that is where I'm getting my feet wet.

This code does the following:

- adds a new call during the atmos_model.F90/atmos_model_init() subroutine to call the newly-created atmos_coupling.F90/ufs_mpas_grid_to_physics() that accepts the newly created GFS_grid_type DDT.
- atmos_coupling.F90/ufs_mpas_grid_to_physics() basically does the same thing as GFS_init.F90/grid_populate(); sets lat/lon in rad/deg, sinlat, coslat, area, and dx. 

I'm using `areaCell` from MPAS for the area, which is straightforward enough. For dx, rather than sqrt(area) as is done for FV3, I found how it is calculated in the standalone MPAS GWD driver, using the `config_len_disp` MPAS configuration variable or the `nominalMinDc`, whichever is available. I copied this code from mpas_atm_core.F/atm_core_init() from the standalone.

This compiles/runs.
